### PR TITLE
fix: Add missing 'draw' method declaration for 'StaticLayout' class

### DIFF
--- a/src/canvas.d.ts
+++ b/src/canvas.d.ts
@@ -86,6 +86,7 @@ export class Paint {
 // }
 export class StaticLayout extends android.text.StaticLayout {
     constructor(text: any, paint: Paint, width: number, align, spacingmult, spacingadd, includepad);
+    public draw(canvas: Canvas): any;
 }
 
 export class FontMetrics {


### PR DESCRIPTION
Class 'StaticLayout' is missing declaration for method 'draw', causing errors during compilation for Android.
```
Argument of type 'import("F:/my-workspace/ui-chart/node_modules/@nativescript-community/ui-canvas/canvas").Canvas' is not assignable to parameter of type 'globalAndroid.graphics.Canvas'.
  Type 'Canvas' is missing the following properties from type 'Canvas': isHardwareAccelerated, drawBitmapMesh, getSaveCount, setMatrix, and 17 more.

679             this.mCenterTextLayout.draw(c);
```