### PR TITLE
fix: Added constructor declarations to avoid TypeScript build errors

### DIFF
--- a/src/canvas.d.ts
+++ b/src/canvas.d.ts
@@ -233,8 +233,12 @@ export class RectF {
     public contains(param0: number, param1: number, param2: number, param3: number): boolean;
     public intersect(param0: number, param1: number, param2: number, param3: number): boolean;
 }
-export class RadialGradient extends android.graphics.RadialGradient {}
-export class LinearGradient extends android.graphics.LinearGradient {}
+export class RadialGradient extends android.graphics.RadialGradient {
+    constructor(param0: number, param1: number, param2: number, param3: any, param4: any, param5: TileMode);
+}
+export class LinearGradient extends android.graphics.LinearGradient {
+    constructor(param0: number, param1: number, param2: number, param3: number, param4: any, param5: any, param6: TileMode);
+}
 export class BitmapShader extends android.graphics.BitmapShader {}
 export class TileMode extends android.graphics.Shader.TileMode {}
 export class Path {


### PR DESCRIPTION
These declarations are needed in order to avoid typescript build errors.
In my case, I tried to set a parameter of type `Color | number` in `LinearGradient` constructor, which was not liked by TypeScript build.