### PR TITLE
fix: Android LinearGradient params were throwing errors.

### DIFF
--- a/src/canvas.android.ts
+++ b/src/canvas.android.ts
@@ -414,7 +414,7 @@ export class Path {
     }
 }
 export class RadialGradient {
-    _native: android.graphics.LinearGradient;
+    _native: android.graphics.RadialGradient;
     getNative() {
         return this._native;
     }
@@ -441,19 +441,23 @@ export class LinearGradient {
         return this._native;
     }
     constructor(param0: number, param1: number, param2: number, param3: any, param4: any, param5: any, param6: any) {
-        if (Array.isArray(param4)) {
-            const testArray = Array.create('int', param4.length);
-            param4.forEach((c, i) => (testArray[i] = createColorParam(c)));
-            param4 = testArray;
-        } else if (param4.hasOwnProperty('length')) {
-            param4 = createColorParam(param4);
+        if (param4 != null) {
+            if (Array.isArray(param4)) {
+                const testArray = Array.create('int', param4.length);
+                param4.forEach((c, i) => (testArray[i] = createColorParam(c)));
+                param4 = testArray;
+            } else {
+                param4 = createColorParam(param4);
+            }
         }
-        if (Array.isArray(param5)) {
-            const testArray = Array.create('float', param4.length);
-            param5.forEach((c, i) => (testArray[i] = c));
-            param5 = testArray;
-        } else if (param5.hasOwnProperty('length')) {
-            param5 = createColorParam(param5);
+        if (param5 != null) {
+            if (Array.isArray(param5)) {
+                const testArray = Array.create('float', param4.length);
+                param5.forEach((c, i) => (testArray[i] = c));
+                param5 = testArray;
+            } else {
+                param5 = createColorParam(param5);
+            }
         }
         this._native = new android.graphics.LinearGradient(param0, param1, param2, param3, param4, param5, param6);
         return new Proxy(this, this);


### PR DESCRIPTION
This fixes `LinearGradient` constructor not recognizing individual colors (color1, color2) and allows `positions` parameter to be nullable (as described in native android docs).
Additionally, type for `RadialGradient`'s `_native` was corrected.