### PR TITLE
Update to NS 8.4

### DIFF
--- a/src/canvas.android.ts
+++ b/src/canvas.android.ts
@@ -2,7 +2,7 @@ import { CSSType, Color, Device, Font, ImageSource, View } from '@nativescript/c
 import { android as androidApp } from '@nativescript/core/application';
 import { FontStyle, FontWeight } from '@nativescript/core/ui/styling/font';
 import lazy from '@nativescript/core/utils/lazy';
-import { layout } from '@nativescript/core/utils/utils';
+import { layout } from '@nativescript/core/utils/layout-helper';
 import { Canvas as ICanvas, Paint as IPaint } from './canvas';
 import { CanvasBase, hardwareAcceleratedProperty } from './canvas.common';
 

--- a/src/canvas.common.ts
+++ b/src/canvas.common.ts
@@ -1,5 +1,5 @@
 import { ChangedData, Observable, ObservableArray, Property, Screen, View, booleanConverter, colorProperty } from '@nativescript/core';
-import { layout } from '@nativescript/core/utils/utils';
+import { layout } from '@nativescript/core/utils/layout-helper';
 import { Canvas, Rect, RectF } from './canvas';
 import Shape from './shapes/shape';
 

--- a/src/canvas.ios.ts
+++ b/src/canvas.ios.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-redeclare */
 import { Font, FontStyle, FontWeight } from '@nativescript/core/ui/styling/font';
 import { CSSType, Color, View, backgroundColorProperty } from '@nativescript/core';
-import { layout } from '@nativescript/core/utils/utils';
+import { layout } from '@nativescript/core/utils/layout-helper';
 import { ImageSource } from '@nativescript/core/image-source';
 import { Canvas as ICanvas, FontMetrics as IFontMetrics, Matrix as IMatrix, Paint as IPaint, Path as IPath, PorterDuffXfermode as IPorterDuffXfermode, Rect as IRect, RectF as IRectF } from './canvas';
 import { CanvasBase } from './canvas.common';

--- a/src/shapes/line.ts
+++ b/src/shapes/line.ts
@@ -1,6 +1,6 @@
 import { CoreTypes } from '@nativescript/core';
 import { PercentLength } from '@nativescript/core/ui/styling/style-properties';
-import { layout } from '@nativescript/core/utils/utils';
+import { layout } from '@nativescript/core/utils/layout-helper';
 import { Canvas, Style } from '../canvas';
 import Rectangle from './rectangle';
 import { percentLengthProperty } from './shape';

--- a/src/shapes/rectangle.ts
+++ b/src/shapes/rectangle.ts
@@ -1,6 +1,6 @@
 import { CoreTypes } from '@nativescript/core';
 import { PercentLength } from '@nativescript/core/ui/styling/style-properties';
-import { layout } from '@nativescript/core/utils/utils';
+import { layout } from '@nativescript/core/utils/layout-helper';
 import { Canvas, Rect, RectF, createRectF } from '../canvas';
 import Shape, { numberProperty, percentLengthProperty } from './shape';
 

--- a/src/shapes/text.ts
+++ b/src/shapes/text.ts
@@ -1,5 +1,5 @@
 import { PercentLength } from '@nativescript/core/ui/styling/style-properties';
-import { layout } from '@nativescript/core/utils/utils';
+import { layout } from '@nativescript/core/utils/layout-helper';
 import { Canvas } from '../canvas';
 import Rectangle from './rectangle';
 import { stringProperty } from './shape';


### PR DESCRIPTION
Hi @farfromrefug ,

layout isn't part from @nativescript/core/utils/utils any more, it can be imported from @nativescript/core/utils/layout-helper but this is not backward compatible with NS 8.3 I think !