### PR TITLE
Update blueprint.md - Add Svelte usage for `ui-canvas`

### DIFF
--- a/packages/ui-canvas/blueprint.md
+++ b/packages/ui-canvas/blueprint.md
@@ -54,9 +54,29 @@ Vue.use(CanvasPlugin);
 <CanvasView  width="100" height="100" @draw="draw"/>
 ```
 
+## NativeScript + Svelte
+
+```ts
+// app/app.ts
+registerNativeViewElement('canvasView', () => require('@nativescript-community/ui-canvas').CanvasView);
+```
+
+```svelte
+// app/components/Foo.svelte
+<stackLayout>
+    <canvasView width="300" height="300" on:draw={draw} />
+</stackLayout>
+```
+
 ## Draw Method 
-```typescript
+
+```ts
+import type { Canvas } from '@nativescript-community/ui-canvas';
+import { Paint, createRect } from '@nativescript-community/ui-canvas';
+import { Color } from '@nativescript/core';
+
 function draw(event: { canvas: Canvas }) {
+    const canvas = event.canvas;
     const paint = new Paint();
     paint.setColor(new Color('black'));
     paint.strokeWidth = 10;

--- a/packages/ui-canvas/blueprint.md
+++ b/packages/ui-canvas/blueprint.md
@@ -63,7 +63,7 @@ registerNativeViewElement('canvasView', () => require('@nativescript-community/u
 ```
 
 ```svelte
-// app/components/Foo.svelte
+<!-- app/components/Foo.svelte -->
 <stackLayout>
     <canvasView width="300" height="300" on:draw={draw} />
 </stackLayout>

--- a/packages/ui-canvas/blueprint.md
+++ b/packages/ui-canvas/blueprint.md
@@ -58,6 +58,7 @@ Vue.use(CanvasPlugin);
 
 ```ts
 // app/app.ts
+import { registerNativeViewElement } from 'svelte-native/dom';
 registerNativeViewElement('canvasView', () => require('@nativescript-community/ui-canvas').CanvasView);
 ```
 


### PR DESCRIPTION
Includes some things helpful to devs: 
1. code comments indicating which file the code belongs in
2. code example includes the imports needed for the example `draw()` method and adds the `canvas` object which is undefined in the current example.
3. shows a layout wrapping the canvas view since it is required.