### PR TITLE
fix(ui-canvas): Android bitmap pixels missing scale

### DIFF
--- a/src/ui-canvas/canvas.android.ts
+++ b/src/ui-canvas/canvas.android.ts
@@ -110,8 +110,9 @@ class Canvas extends ProxyClass<android.graphics.Canvas> {
             } else if (imageOrWidth instanceof android.graphics.Bitmap) {
                 this.mBitmap = imageOrWidth;
             } else {
+                const scale = Screen.mainScreen.scale;
                 this.mShouldReleaseBitmap = true;
-                this.mBitmap = android.graphics.Bitmap.createBitmap(imageOrWidth, height, android.graphics.Bitmap.Config.ARGB_8888);
+                this.mBitmap = android.graphics.Bitmap.createBitmap(imageOrWidth * scale, height * scale, android.graphics.Bitmap.Config.ARGB_8888);
             }
             if (!this.mBitmap.isMutable()) {
                 this.mShouldReleaseBitmap = true;


### PR DESCRIPTION
It seems android Bitmap is missing pixel scaling as it parses width and height as raw pixels.