### PR TITLE
fix(ui-canvas): Incorrect values for bitmap getWidth/getHeight

### DIFF
--- a/src/ui-canvas/canvas.android.ts
+++ b/src/ui-canvas/canvas.android.ts
@@ -122,7 +122,7 @@ class Canvas extends ProxyClass<android.graphics.Canvas> {
 
         return this;
     }
-    override handleCustomMethods(target, native, methodName, args): any {
+    override handleCustomMethods(target: Canvas, native, methodName, args): any {
         if (methodName === 'setBitmap') {
             if (args[0] instanceof ImageSource) {
                 args[0] = args[0].android;
@@ -136,7 +136,7 @@ class Canvas extends ProxyClass<android.graphics.Canvas> {
                 args.pop();
             }
         } else if (methodName === 'getWidth' || methodName === 'getHeight') {
-            if (!target._bitmap) {
+            if (!target.mBitmap) {
                 return Utils.layout.toDeviceIndependentPixels(native[methodName]());
             }
         } else if (methodName === 'clear') {
@@ -198,7 +198,7 @@ export class Paint extends ProxyClass<android.graphics.Paint> {
         this.mNative.setLinearText(true); // ensure we are drawing fonts correctly
         return this;
     }
-    handleCustomMethods(target, native, methodName: string, args: any[]): any {
+    handleCustomMethods(target: Paint, native, methodName: string, args: any[]): any {
         if (methodName === 'setColor') {
             if (!args[0]) {
                 return;


### PR DESCRIPTION
It seems Android Canvas returns unexpected width and height for Bitmap in recent versions.
I realized this unexpected behavior is what resulted in #59.
PR also adds parameter types to avoid such typos in the future.