### PR TITLE
fix(ui-canvas): Proper iOS scale for bitmap cases

### DIFF
--- a/src/ui-canvas/canvas.ios.ts
+++ b/src/ui-canvas/canvas.ios.ts
@@ -1458,10 +1458,10 @@ export class Canvas implements ICanvas {
         const invertedTransform = CGAffineTransformInvert(currentMatrix.mTransform);
         // Screen scale is excluded because it causes problems for other cases (e.g. bitmaps)
         // Android canvas scale has to be re-applied after setMatrix() call too so this is going to make iOS behavior similar
-        const scaleTransform = CGAffineTransformMake(1, 0, 0, -1, 0, this.mHeight);
+        const flipTransform = CGAffineTransformMake(1, 0, 0, -1, 0, this.mHeight);
 
         CGContextConcatCTM(ctx, invertedTransform);
-        CGContextConcatCTM(ctx, scaleTransform);
+        CGContextConcatCTM(ctx, flipTransform);
         CGContextConcatCTM(ctx, matrix.mTransform);
     }
     getMatrix(): Matrix {

--- a/src/ui-canvas/canvas.ios.ts
+++ b/src/ui-canvas/canvas.ios.ts
@@ -1454,10 +1454,11 @@ export class Canvas implements ICanvas {
     setMatrix(matrix: Matrix): void {
         // TODO: Find a better way to implement matrix set
         const ctx = this.ctx;
-        const density = Screen.mainScreen.scale;
         const currentMatrix = this.getMatrix();
         const invertedTransform = CGAffineTransformInvert(currentMatrix.mTransform);
-        const scaleTransform = CGAffineTransformMake(density, 0, 0, -density, 0, density * this.mHeight);
+        // Scale is excluded because it works better for bitmaps that way
+        // Android canvas scale has to be re-applied after setMatrix() call so this is going to make iOS behavior similar
+        const scaleTransform = CGAffineTransformMake(1, 0, 0, -1, 0, this.mHeight);
 
         CGContextConcatCTM(ctx, invertedTransform);
         CGContextConcatCTM(ctx, scaleTransform);

--- a/src/ui-canvas/canvas.ios.ts
+++ b/src/ui-canvas/canvas.ios.ts
@@ -1456,8 +1456,8 @@ export class Canvas implements ICanvas {
         const ctx = this.ctx;
         const currentMatrix = this.getMatrix();
         const invertedTransform = CGAffineTransformInvert(currentMatrix.mTransform);
-        // Scale is excluded because it works better for bitmaps that way
-        // Android canvas scale has to be re-applied after setMatrix() call so this is going to make iOS behavior similar
+        // Screen scale is excluded because it causes problems for other cases (e.g. bitmaps)
+        // Android canvas scale has to be re-applied after setMatrix() call too so this is going to make iOS behavior similar
         const scaleTransform = CGAffineTransformMake(1, 0, 0, -1, 0, this.mHeight);
 
         CGContextConcatCTM(ctx, invertedTransform);


### PR DESCRIPTION
It seems that re-applying screen scale by default during `setMatrix()` call doesn't work well for all cases (e.g. bitmaps).
This PR ensures `setMatrix` sets scale of `1` in the case of bitmaps.