### PR TITLE
chore(ui-canvas): Added missing types for getColorFilter/setColorFilter

### DIFF
--- a/src/ui-canvas/canvas.d.ts
+++ b/src/ui-canvas/canvas.d.ts
@@ -92,7 +92,7 @@ export class Paint extends ProxyClass {
     public setXfermode(param0: PorterDuffXfermode): PorterDuffXfermode;
     public getXfermode(): PorterDuffXfermode;
     public getColorFilter(): ColorFilter;
-    public setColorFilter(param0: ColorFilter): void;
+    public setColorFilter(param0: ColorFilter): ColorFilter;
 }
 
 // export class StaticLayout {

--- a/src/ui-canvas/canvas.d.ts
+++ b/src/ui-canvas/canvas.d.ts
@@ -91,6 +91,7 @@ export class Paint extends ProxyClass {
     // public getFontSpacing(): number;
     public setXfermode(param0: PorterDuffXfermode): PorterDuffXfermode;
     public getXfermode(): PorterDuffXfermode;
+    public getColorFilter(): ColorFilter;
     public setColorFilter(param0: ColorFilter): void;
 }
 

--- a/src/ui-canvas/canvas.ios.ts
+++ b/src/ui-canvas/canvas.ios.ts
@@ -1046,9 +1046,6 @@ export class Paint implements IPaint {
     public getStrokeJoin(): Join {
         return this.strokeJoin;
     }
-    public getColorFilter() {
-        return this.colorFilter;
-    }
     public setStrokeWidth(value: number): void {
         this.strokeWidth = value;
     }
@@ -1088,6 +1085,9 @@ export class Paint implements IPaint {
     }
     public getShader() {
         return this.shader as any as IShader;
+    }
+    public getColorFilter() {
+        return this.colorFilter;
     }
     public setColorFilter(value: any) {
         if (this.colorFilter) {

--- a/src/ui-canvas/canvas.ios.ts
+++ b/src/ui-canvas/canvas.ios.ts
@@ -1089,11 +1089,13 @@ export class Paint implements IPaint {
     public getColorFilter() {
         return this.colorFilter;
     }
-    public setColorFilter(value: any) {
+    public setColorFilter(value: any): any {
         if (this.colorFilter) {
             this.colorFilter.release();
         }
         this.colorFilter = value;
+
+        return value;
     }
     setFont(font: Font) {
         if (font === this.mFont) {


### PR DESCRIPTION
This PR corrects typings for `Paint`'s `getColorFilter`/`setColorFilter`.
I see color filter has no functionality on iOS but typings will still help use it on android.