### PR TITLE
fix(ui-canvas): Canvas iOS bitmaps incorrect shadow offset

### DIFF
--- a/src/ui-canvas/canvas.ios.ts
+++ b/src/ui-canvas/canvas.ios.ts
@@ -1813,8 +1813,7 @@ export class Canvas implements ICanvas {
 
         if (paint.shadowLayer) {
             const s = paint.shadowLayer;
-            // Bitmaps have their coordinate system flipped vertically and that affects shadows offset
-            // so flip shadow offset y as well
+            // Bitmaps have their coordinate system flipped vertically, however shadow offsets ignore this and must be handled manually
             const offsetY = this.mIsBitmap ? -s.dy : s.dy;
 
             CGContextSetShadowWithColor(ctx, CGSizeMake(s.dx, offsetY), s.radius, s.color.ios.CGColor);

--- a/src/ui-canvas/canvas.ios.ts
+++ b/src/ui-canvas/canvas.ios.ts
@@ -1813,7 +1813,11 @@ export class Canvas implements ICanvas {
 
         if (paint.shadowLayer) {
             const s = paint.shadowLayer;
-            CGContextSetShadowWithColor(ctx, CGSizeMake(s.dx, s.dy), s.radius, s.color.ios.CGColor);
+            // Bitmaps have their coordinate system flipped vertically and that affects shadows offset
+            // so flip shadow offset y as well
+            const offsetY = this.mIsBitmap ? -s.dy : s.dy;
+
+            CGContextSetShadowWithColor(ctx, CGSizeMake(s.dx, offsetY), s.radius, s.color.ios.CGColor);
         } else {
             CGContextSetShadow(ctx, CGSizeZero, 0);
         }


### PR DESCRIPTION
This PR fixes canvas shadow offset-y that applies incorrectly when drawing on a bitmap.
That is because we flip bitmap coordinates and according to Apple docs, shadows don't respect that.

> Shadows
> The direction a shadow falls from its object is specified by an offset value, and the meaning of that offset is a convention of a drawing framework. In UIKit, positive x and y offsets make a shadow go down and to the right of an object. In Core Graphics, positive x and y offsets make a shadow go up and to the right of an object. Flipping the CTM to align an object with the default coordinate system of UIKit does not affect the object’s shadow, and so a shadow does not correctly track its object. To get it to track correctly, you must modify the offset values appropriately for the current coordinate system.
> 
> Note: Prior to iOS 3.2, Core Graphics and UIKit shared the same convention for shadow direction: positive offset values make the shadow go down and to the right of an object.

See: https://developer.apple.com/library/archive/documentation/2DDrawing/Conceptual/DrawingPrintingiOS/GraphicsDrawingOverview/GraphicsDrawingOverview.html